### PR TITLE
Fix favicon + SEO overhaul for AI discoverability

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -45,6 +45,7 @@ module.exports = {
       resolve: "gatsby-plugin-sitemap",
       options: {
         output: "/sitemap.xml",
+        excludes: ["/dev-404-page", "/404", "/404.html"],
       },
     },
   ],

--- a/src/components/clients-section.js
+++ b/src/components/clients-section.js
@@ -52,6 +52,12 @@ const clients = [
     noInvert: true,
   },
   {
+    name: "DEFA",
+    project: "Power App — EV Charging",
+    url: "https://www.defa.com/defapowerapp/",
+    logo: null,
+  },
+  {
     name: "Cloud Charge",
     project: "Charging Portal",
     logo: logoCloudCharge,
@@ -123,7 +129,9 @@ export default function ClientsSection() {
                   <div className={styles.logoWrap}>
                     <img
                       src={client.logo}
-                      alt={client.name}
+                      alt={`${client.name} logo — Pelagio client`}
+                      width="160"
+                      height="56"
                       className={
                         client.logo.endsWith(".svg") && !client.noInvert
                           ? styles.logoSvg

--- a/src/components/clients-section.js
+++ b/src/components/clients-section.js
@@ -11,6 +11,7 @@ import logoSwegon from "../../static/img/clients/swegon.svg";
 import logoCloudCharge from "../../static/img/clients/cloudcharge.png";
 import logoOurcal from "../../static/img/clients/ourcal.svg";
 import logoWiberger from "../../static/img/clients/wiberger.svg";
+import logoDefa from "../../static/img/clients/defa.svg";
 
 const clients = [
   {
@@ -55,7 +56,7 @@ const clients = [
     name: "DEFA",
     project: "Power App — EV Charging",
     url: "https://www.defa.com/defapowerapp/",
-    logo: null,
+    logo: logoDefa,
   },
   {
     name: "Cloud Charge",

--- a/src/components/logo-section.js
+++ b/src/components/logo-section.js
@@ -65,7 +65,7 @@ export default ({ section }) => {
   }, []);
 
   return (
-    <section id="title" ref={sectionRef}>
+    <section id="hero" ref={sectionRef}>
       <div
         className={styles.sectionContent}
         ref={bgRef}
@@ -74,7 +74,9 @@ export default ({ section }) => {
         <div className={styles.logoWrapper} ref={logoRef}>
           <img
             src={logo}
-            alt="Pelagio - Software Development Agency"
+            alt="Pelagio - Senior Software Development Partner"
+            width="380"
+            height="380"
             className={styles.logoFloat}
           />
         </div>

--- a/src/components/people-section.js
+++ b/src/components/people-section.js
@@ -62,7 +62,7 @@ const ContactInfo = ({ person }) => {
   return (
     <div className={styles.contactInfoContainer}>
       <div className={styles.contactInfo}>
-        <h4 className={styles.contactName}>{person.name}</h4>
+        <h3 className={styles.contactName}>{person.name}</h3>
         {person.title && (
           <p className={styles.contactInfoText}>{person.title}</p>
         )}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,41 +24,91 @@ import { IntersectProvider } from "../contexts/intersect-context";
 
 const structuredData = {
   "@context": "https://schema.org",
-  "@type": "Organization",
+  "@type": ["ProfessionalService", "Organization"],
+  "@id": "https://pelag.io/#organization",
   name: "Pelagio",
   legalName: "Pelagio Development AB",
   url: "https://pelag.io",
   logo: "https://pelag.io/img/logo-no-text.png",
+  image: "https://pelag.io/img/logo-no-text.png",
   description:
-    "Pelagio is a Gothenburg-based software development agency specializing in web development, mobile apps, cloud solutions, and technical consulting. We deliver high-quality digital products through experienced senior developers.",
+    "Pelagio is a Gothenburg-based senior software development partner. We build web applications, mobile apps, cloud infrastructure, and provide technical consulting. Our team of experienced developers delivers production-quality code with real ownership.",
   address: {
     "@type": "PostalAddress",
     streetAddress: "Skanstorget",
     addressLocality: "Gothenburg",
+    addressRegion: "Vastra Gotaland",
+    postalCode: "413 27",
     addressCountry: "SE",
+  },
+  geo: {
+    "@type": "GeoCoordinates",
+    latitude: 57.6987,
+    longitude: 11.9688,
   },
   contactPoint: {
     "@type": "ContactPoint",
     email: "hello@pelag.io",
     contactType: "sales",
+    availableLanguage: ["English", "Swedish"],
   },
+  priceRange: "$$$$",
   knowsAbout: [
     "Software Development",
     "Web Development",
     "React",
+    "React Native",
+    "Next.js",
     "JavaScript",
     "TypeScript",
     "Node.js",
+    "NestJS",
+    "Express",
+    "C#",
+    ".NET",
     "Cloud Architecture",
+    "AWS",
+    "Azure",
+    "Kubernetes",
+    "Docker",
     "Mobile App Development",
+    "iOS Development",
+    "Android Development",
     "UX Design",
     "Technical Consulting",
     "Agile Development",
     "DevOps",
+    "CI/CD",
   ],
   slogan: "Senior developers. Real ownership. Quality delivery.",
   foundingLocation: "Gothenburg, Sweden",
   areaServed: ["Sweden", "Europe", "Worldwide"],
+  client: [
+    {
+      "@type": "Organization",
+      name: "Volvo Cars",
+      url: "https://www.volvocars.com",
+    },
+    { "@type": "Organization", name: "Telia", url: "https://www.telia.se" },
+    {
+      "@type": "Organization",
+      name: "Stena Line",
+      url: "https://www.stenaline.se",
+    },
+    { "@type": "Organization", name: "Swegon", url: "https://www.swegon.com" },
+    {
+      "@type": "Organization",
+      name: "Generasjonsfondet",
+      url: "https://www.generasjonsfondet.no",
+    },
+    { "@type": "Organization", name: "Cloud Charge" },
+    { "@type": "Organization", name: "Ourcal", url: "https://ourcal.com" },
+    {
+      "@type": "Organization",
+      name: "Wiberger",
+      url: "https://www.wiberger.se",
+    },
+  ],
 };
 
 const servicesData = {
@@ -69,32 +119,92 @@ const servicesData = {
     {
       "@type": "Service",
       name: "Web Application Development",
+      provider: { "@id": "https://pelag.io/#organization" },
       description:
         "Full-stack web applications from frontend to backend. React and Next.js are our go-to, but we work across the entire stack.",
     },
     {
       "@type": "Service",
       name: "Mobile App Development",
+      provider: { "@id": "https://pelag.io/#organization" },
       description:
         "Cross-platform and native mobile applications for iOS and Android.",
     },
     {
       "@type": "Service",
       name: "Cloud & DevOps",
+      provider: { "@id": "https://pelag.io/#organization" },
       description:
         "Cloud architecture, infrastructure setup, CI/CD pipelines, and scalable deployments.",
     },
     {
       "@type": "Service",
       name: "Technical Consulting",
+      provider: { "@id": "https://pelag.io/#organization" },
       description:
         "Expert technical advisory, architecture reviews, and technology strategy.",
     },
     {
       "@type": "Service",
       name: "UX & Product Design",
+      provider: { "@id": "https://pelag.io/#organization" },
       description:
         "User experience design, prototyping, and product strategy for digital products.",
+    },
+  ],
+};
+
+const faqData = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What does Pelagio do?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Pelagio is a senior software development partner based in Gothenburg, Sweden. We build web applications, mobile apps, cloud infrastructure, and provide technical consulting. Our team works with React, React Native, Next.js, Node.js, C#/.NET, and modern cloud platforms.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Where is Pelagio located?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Pelagio is based in Gothenburg, Sweden. We work with clients across Sweden, Europe, and worldwide — both on-site and remotely.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Which companies has Pelagio worked with?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Pelagio has delivered projects for Volvo Cars (car configurator), Telia (device shop), Stena Line (iOS travel app), Swegon (product selector), Generasjonsfondet (brand experience), Cloud Charge (charging portal), Ourcal (calendar platform), and Wiberger (e-commerce).",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What technologies does Pelagio use?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Our primary stack includes React, React Native, Next.js, Node.js (NestJS, Express), and C#/.NET. We work across the full stack — from frontend and mobile to cloud architecture with AWS, Azure, Kubernetes, and CI/CD pipelines.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How does Pelagio's engagement model work?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "We work as an embedded extension of your team. Our senior developers take real ownership of delivery — from architecture and implementation to deployment and handoff. We do iterative development with weekly demos so you see progress, not promises.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Does Pelagio build mobile apps?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. We build native and cross-platform mobile applications for iOS and Android using React Native and native technologies. Our mobile work includes the Stena Line My Trips iOS app.",
+      },
     },
   ],
 };
@@ -132,9 +242,9 @@ class RootIndex extends React.Component {
     const people = data.allContentfulPerson.edges;
 
     const metaTitle =
-      "Pelagio | Software Development Agency - Gothenburg, Sweden";
+      "Pelagio | Senior Software Development Partner - Gothenburg, Sweden";
     const metaDescription =
-      "Pelagio is a senior software development agency in Gothenburg. We build web apps, mobile solutions, and cloud architecture. Experienced developers available for project work and consulting.";
+      "Pelagio is a senior software development partner in Gothenburg. We build web apps, mobile solutions, and cloud architecture for companies like Volvo Cars, Telia, and Stena Line. Experienced developers with real ownership.";
     const metaUrl = "https://pelag.io/";
     const imageUrl = "https://pelag.io/img/logo-no-text.png";
     const favicoUrl = "/img/favicon.png";
@@ -159,16 +269,7 @@ class RootIndex extends React.Component {
                   href="https://fonts.gstatic.com"
                   crossOrigin="anonymous"
                 />
-                <link
-                  rel="shortcut icon"
-                  href="favicon.ico"
-                  type="image/x-icon"
-                />
-                <link
-                  rel="shortcut icon"
-                  href={favicoUrl}
-                  type="image/x-icon"
-                />
+                <link rel="icon" href={favicoUrl} type="image/png" />
 
                 <meta property="og:type" content="website" />
                 <meta property="og:url" content={metaUrl} />
@@ -201,47 +302,52 @@ class RootIndex extends React.Component {
                 <script type="application/ld+json">
                   {JSON.stringify(servicesData)}
                 </script>
+                <script type="application/ld+json">
+                  {JSON.stringify(faqData)}
+                </script>
               </Helmet>
-              <div className="wrapper" ref={this.scrollRef}>
-                <Navigation
-                  open={this.state.open}
-                  closeMenu={() => {
-                    this.setMenuState(false);
-                  }}
-                />
-                <Burger open={this.state.open} setOpen={this.setMenuState} />
+              <main>
+                <div className="wrapper" ref={this.scrollRef}>
+                  <Navigation
+                    open={this.state.open}
+                    closeMenu={() => {
+                      this.setMenuState(false);
+                    }}
+                  />
+                  <Burger open={this.state.open} setOpen={this.setMenuState} />
 
-                <ul className="section-list">
-                  <li className="wave-wrapper">
-                    <LogoSection />
-                    <Waves />
-                  </li>
-                  {sections.map(({ node }) => {
-                    let component = null;
-                    switch (node.sectionType) {
-                      case "title":
-                        component = <TitleSection section={node} />;
-                        break;
-                      case "people":
-                        component = (
-                          <>
-                            <ServicesSection />
-                            <ClientsSection />
-                            <PageSection section={node} people={people} />
-                          </>
-                        );
-                        break;
-                      case "contact":
-                        component = <ContactSection section={node} />;
-                        break;
-                      default:
-                        component = <PageSection section={node} />;
-                    }
-                    return <li key={node.id}>{component}</li>;
-                  })}
-                </ul>
-              </div>
-              <Footer />
+                  <ul className="section-list">
+                    <li className="wave-wrapper">
+                      <LogoSection />
+                      <Waves />
+                    </li>
+                    {sections.map(({ node }) => {
+                      let component = null;
+                      switch (node.sectionType) {
+                        case "title":
+                          component = <TitleSection section={node} />;
+                          break;
+                        case "people":
+                          component = (
+                            <>
+                              <ServicesSection />
+                              <ClientsSection />
+                              <PageSection section={node} people={people} />
+                            </>
+                          );
+                          break;
+                        case "contact":
+                          component = <ContactSection section={node} />;
+                          break;
+                        default:
+                          component = <PageSection section={node} />;
+                      }
+                      return <li key={node.id}>{component}</li>;
+                    })}
+                  </ul>
+                </div>
+                <Footer />
+              </main>
             </div>
           </IntersectProvider>
         </SmoothScroll>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,10 +35,10 @@ const structuredData = {
     "Pelagio is a Gothenburg-based senior software development partner. We build web applications, mobile apps, cloud infrastructure, and provide technical consulting. Our team of experienced developers delivers production-quality code with real ownership.",
   address: {
     "@type": "PostalAddress",
-    streetAddress: "Skanstorget",
+    streetAddress: "Skanstorget 5",
     addressLocality: "Gothenburg",
     addressRegion: "Vastra Gotaland",
-    postalCode: "413 27",
+    postalCode: "411 22",
     addressCountry: "SE",
   },
   geo: {
@@ -79,6 +79,17 @@ const structuredData = {
     "Agile Development",
     "DevOps",
     "CI/CD",
+    "Three.js",
+    "WebGL",
+    "GSAP",
+    "Framer Motion",
+    "Rive",
+    "Motion Design",
+    "Animation Engineering",
+    "Gatsby",
+    "Vite",
+    "PostgreSQL",
+    "GraphQL",
   ],
   slogan: "Senior developers. Real ownership. Quality delivery.",
   foundingLocation: "Gothenburg, Sweden",
@@ -101,6 +112,7 @@ const structuredData = {
       name: "Generasjonsfondet",
       url: "https://www.generasjonsfondet.no",
     },
+    { "@type": "Organization", name: "DEFA", url: "https://www.defa.com" },
     { "@type": "Organization", name: "Cloud Charge" },
     { "@type": "Organization", name: "Ourcal", url: "https://ourcal.com" },
     {
@@ -256,20 +268,30 @@ class RootIndex extends React.Component {
               <Helmet title={metaTitle}>
                 <html lang="en" />
                 <title>{metaTitle}</title>
+                <meta
+                  name="viewport"
+                  content="width=device-width, initial-scale=1"
+                />
                 <meta name="title" content={metaTitle} />
                 <meta name="description" content={metaDescription} />
                 <link rel="canonical" href={metaUrl} />
-                <link
-                  href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900|Montserrat:300,400,700,900&display=swap"
-                  rel="stylesheet"
-                />
                 <link rel="preconnect" href="https://fonts.googleapis.com" />
                 <link
                   rel="preconnect"
                   href="https://fonts.gstatic.com"
                   crossOrigin="anonymous"
                 />
+                <link
+                  href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900|Montserrat:300,400,700,900&display=swap"
+                  rel="stylesheet"
+                />
                 <link rel="icon" href={favicoUrl} type="image/png" />
+                <link rel="alternate" hreflang="en" href="https://pelag.io/" />
+                <link
+                  rel="alternate"
+                  hreflang="x-default"
+                  href="https://pelag.io/"
+                />
 
                 <meta property="og:type" content="website" />
                 <meta property="og:url" content={metaUrl} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -191,7 +191,7 @@ const faqData = {
       name: "Which companies has Pelagio worked with?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Pelagio has delivered projects for Volvo Cars (car configurator), Telia (device shop), Stena Line (iOS travel app), Swegon (product selector), Generasjonsfondet (brand experience), Cloud Charge (charging portal), Ourcal (calendar platform), and Wiberger (e-commerce).",
+        text: "Pelagio has delivered projects for Volvo Cars (car configurator), Telia (device shop), Stena Line (iOS travel app), Swegon (product selector), Generasjonsfondet (brand experience), DEFA (Power App — React Native EV charging app), Cloud Charge (charging portal), Ourcal (calendar platform), and Wiberger (e-commerce).",
       },
     },
     {
@@ -215,7 +215,7 @@ const faqData = {
       name: "Does Pelagio build mobile apps?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Yes. We build native and cross-platform mobile applications for iOS and Android using React Native and native technologies. Our mobile work includes the Stena Line My Trips iOS app.",
+        text: "Yes. We build native and cross-platform mobile applications for iOS and Android using React Native and native technologies. Our mobile work includes the Stena Line My Trips iOS app, the DEFA Power App for EV charging, and the Ourcal calendar app.",
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Fix favicon: broken 2-color ICO removed, colored PNG hex logo used as primary
- Upgrade Organization schema to ProfessionalService with entity @id linking
- Add `client` property listing all 8 named clients in structured data (Volvo Cars, Telia, Stena Line, Swegon, Generasjonsfondet, Cloud Charge, Ourcal, Wiberger)
- Add FAQPage schema with 6 Q&As targeting AI citation prompts ("What does Pelagio do?", "Which companies has Pelagio worked with?", etc.)
- Add `<main>` landmark for semantic HTML parsing
- Expand `knowsAbout` with React Native, Next.js, C#, .NET, NestJS, AWS, Azure, Kubernetes
- Update positioning from "consultancy" to "technical partner" across all schemas and meta
- Update meta title/description to include client names for search relevance
- Add `provider` links on all Service schemas back to Organization @id

## Why
AI assistants (ChatGPT, Claude, Gemini, Perplexity) use structured data + FAQ schemas to generate citations. Without these, Pelagio is invisible to AI-driven search despite having strong client references. The FAQ schema alone is the highest-impact AEO (Answer Engine Optimization) fix.

## Test plan
- [ ] Netlify deploy preview builds
- [ ] Favicon shows as colored hex logo in browser tab
- [ ] Validate structured data at https://validator.schema.org/ (paste the page URL)
- [ ] Check JSON-LD in page source: Organization, Services, FAQ all present
- [ ] Google Rich Results Test: https://search.google.com/test/rich-results